### PR TITLE
Fix the faqQuestionList page title

### DIFF
--- a/templates/faqQuestionList.tpl
+++ b/templates/faqQuestionList.tpl
@@ -1,9 +1,7 @@
-{capture assign='pageTitle'}{lang}wcf.faq.list{/lang}{/capture}
-
 {capture assign='__contentHeader'}
 	<header class="contentHeader">
 		<div class="contentHeaderTitle">
-			<h1 class="contentTitle">{lang}wcf.faq.list{/lang}</h1>
+			<h1 class="contentTitle">{$__wcf->getActivePage()->getTitle()}</h1>
 		</div>
 
 		<nav class="contentHeaderNavigation">
@@ -27,7 +25,7 @@
 
 			<div class="section faq">
 				<h1>{$faq['title']}</h1>
-				
+
 				{if $faq['questions']|isset}
 					{foreach from=$faq['questions'] item=question}
 						{assign var='objectID' value=$question->questionID}
@@ -63,7 +61,7 @@
 
 							<div class="sub">
 								<h1>{$sub['title']}</h1>
-								
+
 								{foreach from=$sub['questions'] item=question}
 									{assign var='objectID' value=$question->questionID}
 
@@ -97,7 +95,7 @@
 		{/if}
 	{/foreach}
 {else}
-    <p class="info">{lang}wcf.global.noItems{/lang}</p>
+	<p class="info">{lang}wcf.global.noItems{/lang}</p>
 {/if}
 
 <footer class="contentFooter">


### PR DESCRIPTION
Currently, it's only possible to change the page title by editing the language item value directly. However, the page title should be retrieved from the values specified in the 'page.xml' PIP (can be changed by editing the page in the ACP).