### PR TITLE
Remove section class from answer containers

### DIFF
--- a/templates/faqQuestionList.tpl
+++ b/templates/faqQuestionList.tpl
@@ -46,7 +46,7 @@
 								{/if}
 							</header>
 							<div class="answer" id="answer-{$question->questionID}">
-								<div class="section htmlContent">
+								<div class="htmlContent">
 									{@$question->getFormattedOutput()}
 								</div>
 
@@ -81,7 +81,7 @@
 											{/if}
 										</header>
 										<div class="answer" id="answer-{$question->questionID}">
-											<div class="section htmlContent">
+											<div class="htmlContent">
 												{@$question->getFormattedOutput()}
 											</div>
 


### PR DESCRIPTION
The `section` class of the answer container causes problems with many styles (due to margins) and isn't needed anyway.

Before this change:
![With section class](https://user-images.githubusercontent.com/12609161/81805362-ffb59500-951a-11ea-9780-13e77e239190.png)

After this change:
![Without section class](https://user-images.githubusercontent.com/12609161/81805372-06440c80-951b-11ea-9cd1-ebba90666068.png)
