### PR TITLE
Fix question title in search results

### DIFF
--- a/files/lib/system/bbcode/FaqBBCode.class.php
+++ b/files/lib/system/bbcode/FaqBBCode.class.php
@@ -42,6 +42,6 @@ class FaqBBCode extends AbstractBBCode
             ]);
         }
 
-        return $question->question . "\n\n" . $question->getPlainOutput();
+        return $question->getTitle() . "\n\n" . $question->getPlainOutput();
     }
 }


### PR DESCRIPTION
The language item name of a question title in the search results isn't translated to the actual content:

![grafik](https://user-images.githubusercontent.com/12609161/196057249-d64597cf-d58f-46e5-9e70-3e15d559850a.png)

This applies only to the parsed BBCode.

In a fixed state, it looks like this:

![grafik](https://user-images.githubusercontent.com/12609161/196057296-781960b0-8547-4d3d-8c79-678361942c2a.png)
