### PR TITLE
Next: 2.2.5

### DIFF
--- a/acptemplates/faqQuestionAdd.tpl
+++ b/acptemplates/faqQuestionAdd.tpl
@@ -14,6 +14,10 @@
 	</nav>
 </header>
 
-{unsafe:$form->getHtml()}
+{if $categories|count}
+	{unsafe:$form->getHtml()}
+{else}
+	<woltlab-core-notice type="error">{lang}wcf.acp.faq.question.error.noCategory{/lang}</woltlab-core-notice>
+{/if}
 
 {include file='footer'}

--- a/files/lib/acp/form/FaqCategoryAddForm.class.php
+++ b/files/lib/acp/form/FaqCategoryAddForm.class.php
@@ -39,8 +39,6 @@ class FaqCategoryAddForm extends CategoryAddFormBuilderForm
     #[Override]
     protected function finalizeForm()
     {
-        parent::finalizeForm();
-
         $this->form->getDataHandler()->addProcessor(
             new CustomFormDataProcessor(
                 'icon',
@@ -59,5 +57,7 @@ class FaqCategoryAddForm extends CategoryAddFormBuilderForm
                 }
             )
         );
+
+        parent::finalizeForm();
     }
 }

--- a/files/lib/acp/form/FaqQuestionAddForm.class.php
+++ b/files/lib/acp/form/FaqQuestionAddForm.class.php
@@ -113,6 +113,7 @@ class FaqQuestionAddForm extends AbstractFormBuilderForm
                             ->label('wcf.acp.faq.question.answer')
                             ->messageObjectType('dev.tkirch.wsc.faq.question')
                             ->attachmentData('dev.tkirch.wsc.faq.question')
+                            ->supportSmilies(true)
                             ->required(),
                     ]);
             }
@@ -139,8 +140,8 @@ class FaqQuestionAddForm extends AbstractFormBuilderForm
                 : WysiwygFormContainer::create('answer')
                     ->label('wcf.acp.faq.question.answer')
                     ->messageObjectType('dev.tkirch.wsc.faq.question')
-                    // ->messageLanguageItemPattern('wcf.faq.question.answer\d+')
                     ->attachmentData('dev.tkirch.wsc.faq.question')
+                    ->supportSmilies(true)
                     ->required()
             ),
             FormContainer::create('position')

--- a/files/lib/data/faq/QuestionEditor.class.php
+++ b/files/lib/data/faq/QuestionEditor.class.php
@@ -2,7 +2,10 @@
 
 namespace wcf\data\faq;
 
+use Override;
 use wcf\data\DatabaseObjectEditor;
+use wcf\data\IEditableCachedObject;
+use wcf\system\cache\builder\FaqQuestionListCacheBuilder;
 use wcf\system\WCF;
 
 /**
@@ -10,12 +13,18 @@ use wcf\system\WCF;
  * @method      Question     getDecoratedObject()
  * @mixin       Question
  */
-final class QuestionEditor extends DatabaseObjectEditor
+final class QuestionEditor extends DatabaseObjectEditor implements IEditableCachedObject
 {
     /**
      * @inheritDoc
      */
     protected static $baseClass = Question::class;
+
+    #[Override]
+    public static function resetCache()
+    {
+        FaqQuestionListCacheBuilder::getInstance()->reset();
+    }
 
     /**
      * Returns the new show order for a object

--- a/files/lib/data/faq/QuestionList.class.php
+++ b/files/lib/data/faq/QuestionList.class.php
@@ -2,7 +2,6 @@
 
 namespace wcf\data\faq;
 
-use wcf\data\attachment\GroupedAttachmentList;
 use wcf\data\DatabaseObjectList;
 
 /**
@@ -18,24 +17,4 @@ final class QuestionList extends DatabaseObjectList
      * @inheritDoc
      */
     public $sqlOrderBy = 'showOrder, questionID';
-
-    private GroupedAttachmentList $attachmentList;
-
-    public function readAttachments()
-    {
-        if (!empty($this->objectIDs)) {
-            $this->attachmentList = new GroupedAttachmentList('dev.tkirch.wsc.faq.question');
-            $this->attachmentList->getConditionBuilder()->add('attachment.objectID IN (?)', [$this->objectIDs]);
-            $this->attachmentList->readObjects();
-        }
-    }
-
-    public function getAttachmentList()
-    {
-        if (!isset($this->attachmentList)) {
-            $this->readAttachments();
-        }
-
-        return $this->attachmentList;
-    }
 }

--- a/files/lib/data/faq/category/FaqCategory.class.php
+++ b/files/lib/data/faq/category/FaqCategory.class.php
@@ -13,6 +13,7 @@ use wcf\system\category\CategoryPermissionHandler;
 use wcf\system\request\LinkHandler;
 use wcf\system\style\FontAwesomeIcon;
 use wcf\system\WCF;
+use wcf\util\StringUtil;
 
 /**
  * @method      FaqCategory[]    getChildCategories()
@@ -86,13 +87,27 @@ final class FaqCategory extends AbstractDecoratedCategory implements IAccessible
         ]);
     }
 
-    public function getIcon(int $size = 24): string
+    public function getDescription(): string
+    {
+        return WCF::getLanguage()->get($this->description);
+    }
+
+    public function getDescriptionHtml(): string
+    {
+        return $this->descriptionUseHtml ? $this->getDescription() : StringUtil::encodeHTML($this->getDescription());
+    }
+
+    public function getIcon(int $size = 24, bool $defaultIcon = false): string
     {
         if (
             isset($this->additionalData['faqIcon'])
             && FontAwesomeIcon::isValidString($this->additionalData['faqIcon'])
         ) {
             return FontAwesomeIcon::fromString($this->additionalData['faqIcon'])->toHtml($size);
+        }
+
+        if ($defaultIcon) {
+            return FontAwesomeIcon::fromString('circle-question;false')->toHtml($size);
         }
 
         return '';

--- a/files/lib/page/FaqQuestionListPage.class.php
+++ b/files/lib/page/FaqQuestionListPage.class.php
@@ -74,11 +74,8 @@ class FaqQuestionListPage extends AbstractPage
             }
 
             $faq = [
-                'id' => $category->categoryID,
-                'title' => WCF::getLanguage()->get($category->title),
+                'category' => $category,
                 'attachments' => $attachmentList,
-                'icon24' => $category->getIcon(24),
-                'icon64' => $category->getIcon(64),
                 'questions' => [],
             ];
 

--- a/files/lib/page/FaqQuestionListPage.class.php
+++ b/files/lib/page/FaqQuestionListPage.class.php
@@ -73,16 +73,13 @@ class FaqQuestionListPage extends AbstractPage
             $questionList->getConditionBuilder()->add('categoryID = ?', [$category->categoryID]);
             $questionList->readObjects();
 
-            if (!\count($questionList)) {
-                continue;
-            }
-
             $faq = [
                 'id' => $category->categoryID,
                 'title' => WCF::getLanguage()->get($category->title),
-                'attachments' => $questionList->getAttachmentList(),
+                'attachments' => count($questionList) ? $questionList->getAttachmentList() : [],
                 'icon24' => $category->getIcon(24),
                 'icon64' => $category->getIcon(64),
+                'questions' => [],
             ];
 
             foreach ($questionList->getObjects() as $question) {

--- a/files/lib/page/FaqQuestionListPage.class.php
+++ b/files/lib/page/FaqQuestionListPage.class.php
@@ -4,10 +4,11 @@ namespace wcf\page;
 
 use CuyZ\Valinor\Mapper\MappingError;
 use Override;
+use wcf\data\attachment\GroupedAttachmentList;
 use wcf\data\faq\category\FaqCategory;
 use wcf\data\faq\category\FaqCategoryNodeTree;
-use wcf\data\faq\QuestionList;
 use wcf\http\Helper;
+use wcf\system\cache\builder\FaqQuestionListCacheBuilder;
 use wcf\system\exception\IllegalLinkException;
 use wcf\system\message\embedded\object\MessageEmbeddedObjectManager;
 use wcf\system\WCF;
@@ -18,6 +19,8 @@ class FaqQuestionListPage extends AbstractPage
      * @inheritDoc
      */
     public $neededPermissions = ['user.faq.canViewFAQ'];
+
+    protected array $faqs = [];
 
     protected int $showFaqAddDialog = 0;
 
@@ -49,14 +52,15 @@ class FaqQuestionListPage extends AbstractPage
     }
 
     #[Override]
-    public function assignVariables()
+    public function readData()
     {
-        parent::assignVariables();
+        parent::readData();
 
         //get categories
-        $faqs = [];
         $embedObjectIDs = [];
         $categoryTree = new FaqCategoryNodeTree('dev.tkirch.wsc.faq.category');
+        [$questionList, $questionIDs] = FaqQuestionListCacheBuilder::getInstance()->getData();
+        $attachmentList = $this->getAttachmentList($questionIDs);
         foreach ($categoryTree->getIterator() as $category) {
             if (!$category->isAccessible()) {
                 continue;
@@ -69,20 +73,17 @@ class FaqQuestionListPage extends AbstractPage
                 continue;
             }
 
-            $questionList = new QuestionList();
-            $questionList->getConditionBuilder()->add('categoryID = ?', [$category->categoryID]);
-            $questionList->readObjects();
-
             $faq = [
                 'id' => $category->categoryID,
                 'title' => WCF::getLanguage()->get($category->title),
-                'attachments' => count($questionList) ? $questionList->getAttachmentList() : [],
+                'attachments' => $attachmentList,
                 'icon24' => $category->getIcon(24),
                 'icon64' => $category->getIcon(64),
                 'questions' => [],
             ];
 
-            foreach ($questionList->getObjects() as $question) {
+            $questions = $questionList[$category->categoryID] ?? [];
+            foreach ($questions as $question) {
                 if ($question->isAccessible()) {
                     $faq['questions'][] = $question;
                     if ($question->hasEmbeddedObjects) {
@@ -92,22 +93,41 @@ class FaqQuestionListPage extends AbstractPage
             }
 
             if ($category->getParentNode() && $category->getParentNode()->categoryID) {
-                $faqs[$category->getParentNode()->categoryID]['sub'][$category->categoryID] = $faq;
+                $this->faqs[$category->getParentNode()->categoryID]['sub'][$category->categoryID] = $faq;
             } else {
-                $faqs[$category->categoryID] = $faq;
+                $this->faqs[$category->categoryID] = $faq;
             }
         }
 
-        if (\count($embedObjectIDs)) {
+        if ($embedObjectIDs !== []) {
             MessageEmbeddedObjectManager::getInstance()->loadObjects(
                 'dev.tkirch.wsc.faq.question',
                 $embedObjectIDs
             );
         }
+    }
+
+    #[Override]
+    public function assignVariables()
+    {
+        parent::assignVariables();
 
         WCF::getTPL()->assign([
-            'faqs' => $faqs,
+            'faqs' => $this->faqs,
             'showFaqAddDialog' => $this->showFaqAddDialog,
         ]);
+    }
+
+    protected function getAttachmentList(array $questionIDs): array|GroupedAttachmentList
+    {
+        if ($questionIDs === []) {
+            return [];
+        }
+
+        $attachmentList = new GroupedAttachmentList('dev.tkirch.wsc.faq.question');
+        $attachmentList->getConditionBuilder()->add('attachment.objectID IN (?)', [$questionIDs]);
+        $attachmentList->readObjects();
+
+        return $attachmentList;
     }
 }

--- a/files/lib/system/box/FaqCategoriesBoxController.class.php
+++ b/files/lib/system/box/FaqCategoriesBoxController.class.php
@@ -46,6 +46,9 @@ final class FaqCategoriesBoxController extends AbstractCategoriesBoxController
     #[Override]
     public function hasContent()
     {
-        return SIMPLE_FAQ_VIEW !== 'gallery';
+        $categoryTree = $this->getNodeTree();
+        $categoryList = $categoryTree->getIterator();
+
+        return SIMPLE_FAQ_VIEW !== 'gallery' && \iterator_count($categoryList);
     }
 }

--- a/files/lib/system/cache/builder/FaqQuestionListCacheBuilder.class.php
+++ b/files/lib/system/cache/builder/FaqQuestionListCacheBuilder.class.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace wcf\system\cache\builder;
+
+use Override;
+use wcf\data\faq\QuestionList;
+
+final class FaqQuestionListCacheBuilder extends AbstractCacheBuilder
+{
+    #[Override]
+    protected function rebuild(array $parameters)
+    {
+        $questionList = new QuestionList();
+        $questionList->readObjects();
+
+        $questions = [];
+        foreach ($questionList as $question) {
+            $questions[$question->categoryID][] = $question;
+        }
+
+        return [$questions, $questionList->getObjectIDs()];
+    }
+}

--- a/files/lib/system/category/FaqCategoryType.class.php
+++ b/files/lib/system/category/FaqCategoryType.class.php
@@ -14,7 +14,7 @@ final class FaqCategoryType extends AbstractCategoryType
     /**
      * @inheritDoc
      */
-    protected $hasDescription = false;
+    protected $hasDescription = true;
 
     /**
      * @inheritDoc
@@ -42,7 +42,14 @@ final class FaqCategoryType extends AbstractCategoryType
     protected function init()
     {
         $this->maximumNestingLevel = SIMPLE_FAQ_VIEW === 'gallery' ? 0 : 1;
+        $this->hasDescription = SIMPLE_FAQ_VIEW === 'gallery' ? false : true;
 
         parent::init();
+    }
+
+    #[Override]
+    public function supportsHtmlDescription()
+    {
+        return SIMPLE_FAQ_VIEW === 'gallery' ? false : true;
     }
 }

--- a/files/style/faq.scss
+++ b/files/style/faq.scss
@@ -43,18 +43,22 @@
 }
 
 .faq {
-	> h2 {
-    	font-size: 1.5rem;
-		border-bottom: 1px solid currentColor;
-		padding-bottom: 10px
+	> .sectionHeader {
+		h2 {
+			font-size: 1.5rem !important;
+		}
+		border-bottom: 1px solid currentColor !important;
+		padding-bottom: 10px;
 	}
 	> .sub {
 		margin-top: 16px;
 		margin-bottom: 8px;
 		margin-left: 16px;
-		> h2 {
-			font-size: 1.3rem;
-			border-bottom: 1px solid currentColor;
+		.sectionHeader {
+			h2 {
+				font-size: 1.3rem !important;
+			}
+			border-bottom: 1px solid currentColor !important;
 			padding-bottom: 10px;
 		}
 	}

--- a/package.xml
+++ b/package.xml
@@ -6,8 +6,8 @@
 		<packagename language="de">Simple FAQ</packagename>
 		<packagedescription>A simple and powerful FAQ for your WSC.</packagedescription>
 		<packagedescription language="de">Ein simples und leistungsstarkes FAQ für Ihr WSC.</packagedescription>
-		<version>2.2.4</version>
-		<date>2024-10-29</date>
+		<version>2.2.5</version>
+		<date>2024-11-03</date>
 	</packageinformation>
 	<authorinformation>
 		<author>Hanashi Development, Titus Kirch</author>
@@ -36,8 +36,10 @@
 		<instruction type="templateListener"/>
 		<instruction type="database" run="standalone">acp/database/install_dev.tkirch.wsc.faq.php</instruction>
 	</instructions>
-	<instructions type="update" fromversion="2.2.3">
-		<instruction type="language"/>
+	<instructions type="update" fromversion="2.2.4">
+		<instruction type="file"/>
+		<instruction type="acpTemplate"/>
+		<instruction type="template"/>
 	</instructions>
 	<instructions type="update" fromversion="2.1.*">
 		<instruction type="file"/>

--- a/templates/faqQuestionAdd.tpl
+++ b/templates/faqQuestionAdd.tpl
@@ -18,6 +18,10 @@
 
 {include file='header' contentHeader=$__contentHeader}
 
-{unsafe:$form->getHtml()}
+{if $categories|count}
+	{unsafe:$form->getHtml()}
+{else}
+	<woltlab-core-notice type="error">{lang}wcf.acp.faq.question.error.noCategory{/lang}</woltlab-core-notice>
+{/if}
 
 {include file='footer'}

--- a/templates/faqQuestionList.tpl
+++ b/templates/faqQuestionList.tpl
@@ -23,13 +23,9 @@
 		<div class="faqGallery">
 			{foreach from=$faqs item=faq}
 				{if ($faq['questions']|isset && $faq['questions']|count)}
-					<button type="button" class="button galleryButton" data-id="{$faq['id']}">
-						{if $faq['icon64'] === ''}
-							{icon name='circle-question' size=64}
-						{else}
-							{unsafe:$faq['icon64']}
-						{/if}
-						{$faq['title']}
+					<button type="button" class="button galleryButton" data-id="{$faq['category']->categoryID}">
+						{unsafe:$faq['category']->getIcon(64, true)}
+						{$faq['category']->getTitle()}
 					</button>
 				{/if}
 			{/foreach}
@@ -46,8 +42,8 @@
 			{if ($faq['questions']|isset && $faq['questions']|count)}
 				{assign var='attachmentList' value=$faq['attachments']}
 
-				<div id="faqSection{$faq['id']}" class="section faqGallerySection jsObjectActionContainer faq" data-object-action-class-name="wcf\data\faq\QuestionAction" style="display: none;">
-					<h2>{unsafe:$faq['icon24']} {$faq['title']}</h2>
+				<div id="faqSection{$faq['category']->categoryID}" class="section faqGallerySection jsObjectActionContainer faq" data-object-action-class-name="wcf\data\faq\QuestionAction" style="display: none;">
+					<h2>{unsafe:$faq['category']->getIcon(24)} {$faq['category']->getTitle()}</h2>
 
 					{if $faq['questions']|isset}
 						{foreach from=$faq['questions'] item=question}
@@ -64,7 +60,10 @@
 					{assign var='attachmentList' value=$faq['attachments']}
 
 					<div class="section faq{if SIMPLE_FAQ_VIEW === 'cleave'} cleaveCategory{/if}">
-						<h2>{unsafe:$faq['icon24']} {$faq['title']}</h2>
+						<header class="sectionHeader">
+							<h2 class="sectionTitle">{unsafe:$faq['category']->getIcon(24)} {$faq['category']->getTitle()}</h2>
+							<p class="sectionDescription">{unsafe:$faq['category']->getDescriptionHtml()}</p>
+						</header>
 
 						{if $faq['questions']|isset}
 							{foreach from=$faq['questions'] item=question}
@@ -78,7 +77,10 @@
 									{assign var='attachmentList' value=$sub['attachments']}
 
 									<div class="sub">
-										<h2>{$sub['title']}</h2>
+										<header class="sectionHeader">
+											<h2 class="sectionTitle">{unsafe:$sub['category']->getIcon(24)} {$sub['category']->getTitle()}</h2>
+											<p class="sectionDescription">{unsafe:$sub['category']->getDescriptionHtml()}</p>
+										</header>
 
 										{foreach from=$sub['questions'] item=question}
 											{include file='__faqQuestionListEntry'}


### PR DESCRIPTION
Version für WSC 6.1

**Neue Funktionen**

- Kategorien können nun Beschreibungen enthalten
- Performanceverbesserungen

**Fehlerbehebungen**

- wenn noch keine Kategorie angelegt war, wurde eine Fehlermeldung angezeigt, bei der der HTML-Code enkodiert war
- die Kategoriebox wurde angezeigt obwohl keine Kategorien existierten
- wenn eine Elternkategorie keine Fragen enthielt, konnte eine Fehlermeldung erscheinen
- das Icon bei den Kategorien konnte im ACP nicht gespeichert werden
- Smileys wurden auch angezeigt wenn das Modul für Smileys deaktiviert war